### PR TITLE
Ignore voice availability when in UI preview (edit mode)

### DIFF
--- a/library/src/main/java/com/search/material/library/MaterialSearchView.java
+++ b/library/src/main/java/com/search/material/library/MaterialSearchView.java
@@ -250,6 +250,8 @@ public class MaterialSearchView extends FrameLayout implements Filter.FilterList
     }
 
     private boolean isVoiceAvailable() {
+        if (isInEditMode())
+            return false;
         PackageManager pm = getContext().getPackageManager();
         List<ResolveInfo> activities = pm.queryIntentActivities(
                 new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH), 0);


### PR DESCRIPTION
When editing an XML layout with the MaterialSearchView, the preview pane reports a nasty crash, ruining our nice edit mode. This is due to an (during edit mode unnecessary) dependence on voice availability checking.
